### PR TITLE
Upgrade build configuration, dependencies, and time APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ xcuserdata/
 Pods/
 *.jks
 *yarn.lock
+/.kotlin/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.android.application).apply(false)
     alias(libs.plugins.buildConfig).apply(false)
     alias(libs.plugins.kotlinx.serialization).apply(false)
+    alias(libs.plugins.compose.compiler).apply(false)
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -6,18 +6,16 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.buildConfig)
     alias(libs.plugins.kotlinx.serialization)
+    alias(libs.plugins.compose.compiler)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
 kotlin {
-    targetHierarchy.default()
-    androidTarget {
-        compilations.all {
-            kotlinOptions {
-                jvmTarget = "17"
-            }
-        }
-    }
+    jvmToolchain(jdkVersion = 17)
+
+    kotlin.applyDefaultHierarchyTemplate()
+
+    androidTarget()
 
     jvm("desktop")
 
@@ -99,11 +97,11 @@ kotlin {
 
 android {
     namespace = "sternbach.software.kosherkotlin"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
 
         applicationId = "sternbach.software.kosherkotlin.androidApp"
         versionCode = 1

--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/AstronomicalCalendar.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/AstronomicalCalendar.kt
@@ -15,11 +15,23 @@
  */
 package sternbach.software.kosherkotlin
 
-import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.DateTimePeriod
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.plus
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import sternbach.software.kosherkotlin.AstronomicalCalendar.Companion.ASTRONOMICAL_ZENITH
+import sternbach.software.kosherkotlin.AstronomicalCalendar.Companion.CIVIL_ZENITH
+import sternbach.software.kosherkotlin.AstronomicalCalendar.Companion.NAUTICAL_ZENITH
+import sternbach.software.kosherkotlin.AstronomicalCalendar.Companion.getTimeOffset
 import sternbach.software.kosherkotlin.util.AstronomicalCalculator
 import sternbach.software.kosherkotlin.util.GeoLocation
-import kotlinx.datetime.*
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Instant
 
 /**
  * A Java calendar that calculates astronomical times such as [sunrise], [sunset] and twilight times. This class contains a [Calendar][calendar] and can therefore use the standard

--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/ComplexZmanimCalendar.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/ComplexZmanimCalendar.kt
@@ -15,7 +15,44 @@
  */
 package sternbach.software.kosherkotlin
 
-import kotlinx.datetime.*
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.plus
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.todayIn
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_10_POINT_2
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_11_DEGREES
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_11_POINT_5
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_13_POINT_24
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_16_POINT_9
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_19_DEGREES
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_19_POINT_8
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_1_POINT_583
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_26_DEGREES
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_3_POINT_65
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_3_POINT_676
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_3_POINT_7
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_3_POINT_8
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_4_POINT_37
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_4_POINT_61
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_4_POINT_8
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_5_POINT_88
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_5_POINT_95
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_6_DEGREES
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_6_POINT_45
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_7_POINT_083
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_7_POINT_65
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_7_POINT_67
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_9_POINT_3
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_9_POINT_5
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_9_POINT_75
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_MINUS_2_POINT_1
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_MINUS_2_POINT_8
+import sternbach.software.kosherkotlin.ComplexZmanimCalendar.Companion.ZENITH_MINUS_3_POINT_05
 import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar
 import sternbach.software.kosherkotlin.metadata.UsesElevation
 import sternbach.software.kosherkotlin.metadata.ZmanAuthority
@@ -30,11 +67,12 @@ import sternbach.software.kosherkotlin.metadata.ZmanType
 import sternbach.software.kosherkotlin.util.AstronomicalCalculator
 import sternbach.software.kosherkotlin.util.GeoLocation
 import sternbach.software.kosherkotlin.util.GeoLocation.Companion.rawOffset
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
-
+import kotlin.time.Instant
 
 /**
  *

--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/Main.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/Main.kt
@@ -1,9 +1,10 @@
 package sternbach.software.kosherkotlin
 
+import kotlinx.datetime.LocalTime
 import sternbach.software.kosherkotlin.hebrewcalendar.HebrewLocalDate
 import sternbach.software.kosherkotlin.hebrewcalendar.HebrewMonth
 import sternbach.software.kosherkotlin.util.GeoLocation
-import kotlinx.datetime.*
+import kotlin.time.Clock
 
 fun main(args: Array<String>) {
     println(Clock.System.now().toString())
@@ -71,7 +72,7 @@ val lakewood = GeoLocation("Lakewood, NJ", 40.0721087, -74.2400243, 15.0, kotlin
 //    println(days.milliseconds.inWholeNanoseconds)
     println(Long.MAX_VALUE)
     val year6000 = HebrewLocalDate(6000, HebrewMonth.TISHREI, 1).toLocalDateGregorian()
-    val midnight = LocalTime(0,0,0)
+    val midnight = LocalTime(0, 0, 0)
 //    fun kotlinx.datetime.TimeZone.toJava() = java.util.TimeZone.getTimeZone(id)
 //    fun GeoLocation.toJava() = com.kosherjava.java.zmanim.util.GeoLocation(locationName, latitude, longitude, elevation, timeZone.toJava())
 //    println(days.inWholeNanoseconds)

--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/HebrewLocalDate.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/HebrewLocalDate.kt
@@ -1,8 +1,15 @@
 package sternbach.software.kosherkotlin.hebrewcalendar
 
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.Month
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import sternbach.software.kosherkotlin.hebrewcalendar.HebrewLocalDate.Companion.STARTING_DATE_HEBREW
 import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate.Companion.daysInJewishYear
 import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate.Companion.isJewishLeapYear
-import kotlinx.datetime.*
 import kotlin.time.Duration.Companion.days
 
 /**

--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/JewishCalendar.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/JewishCalendar.kt
@@ -17,24 +17,38 @@
  */
 package sternbach.software.kosherkotlin.hebrewcalendar
 
-import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Parsha.NONE
-import sternbach.software.kosherkotlin.util.GeoLocation
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
-
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Companion.CHANUKAH
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Companion.CHOL_HAMOED_PESACH
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Companion.CHOL_HAMOED_SUCCOS
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Companion.HOSHANA_RABBA
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Companion.PESACH
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Companion.PESACH_SHENI
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Companion.ROSH_HASHANA
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Companion.SHAVUOS
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Companion.SHEMINI_ATZERES
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Companion.SIMCHAS_TORAH
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Companion.SUCCOS
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Companion.TU_BEAV
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Companion.YOM_HAATZMAUT
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Companion.YOM_KIPPUR
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Companion.toJewishDayOfWeek
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar.Parsha.NONE
+import sternbach.software.kosherkotlin.util.GeoLocation
 import kotlin.math.floor
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 /**
  * The JewishCalendar extends the JewishDate class and adds calendar methods.

--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/JewishDate.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/JewishDate.kt
@@ -16,9 +16,18 @@
  */
 package sternbach.software.kosherkotlin.hebrewcalendar
 
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
 import sternbach.software.kosherkotlin.hebrewcalendar.HebrewLocalDate.Companion.toHebrewDate
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate.Companion.CHASERIM
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate.Companion.KESIDRAN
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate.Companion.SHELAIMIM
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate.Companion.isCheshvanLong
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate.Companion.isJewishLeapYear
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate.Companion.isKislevShort
 import sternbach.software.kosherkotlin.util.DateUtils.now
-import kotlinx.datetime.*
 
 /**
  * The JewishDate is the base calendar class, that supports maintenance of a [LocalDateTime]

--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/YerushalmiYomiCalculator.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/YerushalmiYomiCalculator.kt
@@ -15,8 +15,6 @@
  */
 package sternbach.software.kosherkotlin.hebrewcalendar
 
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.Month
@@ -24,8 +22,9 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.daysUntil
 import kotlinx.datetime.toInstant
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
-
+import kotlin.time.Instant
 
 /**
  * This class calculates the [Talmud Yerusalmi](https://en.wikipedia.org/wiki/Jerusalem_Talmud) [Daf Yomi](https://en.wikipedia.org/wiki/Daf_Yomi) page ([Daf]) for the a given date.

--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/YomiCalculator.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/YomiCalculator.kt
@@ -15,8 +15,8 @@
  */
 package sternbach.software.kosherkotlin.hebrewcalendar
 
-import sternbach.software.kosherkotlin.util.*
 import kotlinx.datetime.LocalDate
+import sternbach.software.kosherkotlin.util.DateUtils
 
 /**
  * This class calculates the Daf Yomi Bavli page (daf) for a given date. To calculate Daf Yomi Yerushalmi

--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/package-info.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/package-info.kt
@@ -17,10 +17,3 @@
  * @author  Eliyahu Hershfeld 2011 - 2022
  */
 package sternbach.software.kosherkotlin.hebrewcalendar
-
-import sternbach.software.kosherkotlin.hebrewcalendar.Daf
-import sternbach.software.kosherkotlin.hebrewcalendar.HebrewDateFormatter
-import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar
-import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate
-import sternbach.software.kosherkotlin.hebrewcalendar.YerushalmiYomiCalculator
-import sternbach.software.kosherkotlin.hebrewcalendar.YomiCalculator

--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/util/DateUtils.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/util/DateUtils.kt
@@ -1,7 +1,10 @@
 package sternbach.software.kosherkotlin.util
 
-import kotlinx.datetime.*
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import kotlin.math.floor
+import kotlin.time.Clock
 
 /**
  * TODO this is debateably an anti-pattern. Figure out where to put these functinos.

--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/util/GeoLocation.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/util/GeoLocation.kt
@@ -18,9 +18,15 @@ package sternbach.software.kosherkotlin.util
 import sternbach.software.kosherkotlin.util.AstronomicalCalculator.Companion.toDegrees
 import sternbach.software.kosherkotlin.util.AstronomicalCalculator.Companion.toRadians
 import kotlinx.datetime.TimeZone
-
-
-import kotlin.math.*
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.atan
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.ln
+import kotlin.math.sin
+import kotlin.math.sqrt
+import kotlin.math.tan
 
 /**
  * A class that contains location information such as latitude and longitude required for astronomical calculations. The

--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/util/NOAACalculator.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/util/NOAACalculator.kt
@@ -17,9 +17,12 @@ package sternbach.software.kosherkotlin.util
 
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
-
-import sternbach.software.kosherkotlin.hebrewcalendar.*
-import kotlin.math.*
+import kotlin.math.acos
+import kotlin.math.asin
+import kotlin.math.atan
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.tan
 
 /**
  * Implementation of sunrise and sunset methods to calculate astronomical times based on the [NOAA](https://noaa.gov) algorithm. This calculator uses the Java algorithm based on the implementation by [NOAA - National Oceanic and Atmospheric Administration](https://noaa.gov)'s [Surface Radiation Research Branch](https://www.srrb.noaa.gov/highlights/sunrise/sunrise.html). NOAA's [implementation](https://www.srrb.noaa.gov/highlights/sunrise/solareqns.PDF) is based on equations from [Astronomical Algorithms](https://www.amazon.com/Astronomical-Table-Sun-Moon-Planets/dp/1942675038/) by [Jean Meeus](https://en.wikipedia.org/wiki/Jean_Meeus). Added to the algorithm is an adjustment of the zenith

--- a/composeApp/src/test/kotlin/hebrewcalendar/ConvertBetweenGregorianAndHebrewTest.kt
+++ b/composeApp/src/test/kotlin/hebrewcalendar/ConvertBetweenGregorianAndHebrewTest.kt
@@ -1,14 +1,16 @@
 package hebrewcalendar
 
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.plus
 import sternbach.software.kosherkotlin.hebrewcalendar.HebrewLocalDate.Companion.toHebrewDate
 import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate.Companion.daysInJewishYear
-import sternbach.software.kosherkotlin.util.DateUtils.now
-import kotlinx.datetime.*
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import sternbach.software.kosherkotlin.hebrewcalendar.HebrewLocalDate
 import sternbach.software.kosherkotlin.hebrewcalendar.HebrewMonth
-import java.util.*
+import sternbach.software.kosherkotlin.util.DateUtils.now
+import java.time.LocalDate
+import java.util.Calendar
 
 class ConvertBetweenGregorianAndHebrewTest {
 
@@ -114,7 +116,7 @@ class ConvertBetweenGregorianAndHebrewTest {
             HebrewLocalDate.STARTING_DATE_GREGORIAN,
             HebrewLocalDate.STARTING_DATE_HEBREW.toLocalDateGregorian()
         )
-        val distantFuture = LocalDate(100_000, 1, 1)
+        val distantFuture = kotlinx.datetime.LocalDate(100_000, 1, 1)
         val distantFutureHebrew = HebrewLocalDate(103759, HebrewMonth.CHESHVAN, 22)
         assertEquals(distantFuture, distantFutureHebrew.toLocalDateGregorian())
     }
@@ -123,13 +125,13 @@ class ConvertBetweenGregorianAndHebrewTest {
     fun `gregorian to hebrew - min and max date`() {
         assertEquals(HebrewLocalDate.STARTING_DATE_HEBREW, HebrewLocalDate.STARTING_DATE_GREGORIAN.toHebrewDate())
         val distantFutureHebrew = HebrewLocalDate(103_759, HebrewMonth.CHESHVAN, 22)
-        val distantFuture = LocalDate(100_000, 1, 1)
+        val distantFuture = kotlinx.datetime.LocalDate(100_000, 1, 1)
         assertEquals(distantFutureHebrew, distantFuture.toHebrewDate())
     }
 
     @Test
     fun twoWayConversion() {
-        val now = LocalDate.now() //probably bad practice to use a value which can change between tests
+        val now = kotlinx.datetime.LocalDate.now() //probably bad practice to use a value which can change between tests
         assertEquals(now, now.toHebrewDate().toLocalDateGregorian())
     }
 
@@ -138,7 +140,7 @@ class ConvertBetweenGregorianAndHebrewTest {
         val newGregorianDate = HebrewLocalDate.STARTING_DATE_GREGORIAN.plus(DatePeriod(years = 1, months = 1))
         val distantFutureJewishDate =
             com.kosherjava.zmanim.hebrewcalendar.JewishDate(
-                java.time.LocalDate.of(
+                LocalDate.of(
                     newGregorianDate.year,
                     newGregorianDate.month,
                     newGregorianDate.dayOfMonth
@@ -179,7 +181,7 @@ class ConvertBetweenGregorianAndHebrewTest {
     @Test
     fun `6th month doesn't work (for some reason)`() {
         val hebrew = HebrewLocalDate(4483, HebrewMonth.ELUL, 29)
-        val gregorian = LocalDate(723, 9, 9)
+        val gregorian = kotlinx.datetime.LocalDate(723, 9, 9)
         assertEquals(hebrew, gregorian.toHebrewDate())
         assertEquals(gregorian, hebrew.toLocalDateGregorian())
     }
@@ -198,22 +200,22 @@ class ConvertBetweenGregorianAndHebrewTest {
 
 
     // Simple cases, before starting date
-/*
-    @Test
-    fun lessThanMonthBeforeStartingDate() {
-        val numDaysToSubtract = 3
-        val date = HebrewLocalDate.STARTING_DATE_GREGORIAN.minus(DatePeriod(days = numDaysToSubtract))
-        println("Date: $date")
-        val hebrew = HebrewLocalDate.STARTING_DATE_HEBREW
-        val expectedNewMonth = hebrew.month.previousMonth
-        val expectedNewYear = hebrew.year - 1
-        val daysInJewishMonth = JewishDate.getDaysInJewishMonth(expectedNewMonth, expectedNewYear)
-        println("Days in jewish month: $daysInJewishMonth")
-        assertEquals(
-            HebrewLocalDate(
-                expectedNewYear,
-                expectedNewMonth,
-                daysInJewishMonth - numDaysToSubtract + hebrew.dayOfMonth*//*include starting day of old year*//*
+    /*
+        @Test
+        fun lessThanMonthBeforeStartingDate() {
+            val numDaysToSubtract = 3
+            val date = HebrewLocalDate.STARTING_DATE_GREGORIAN.minus(DatePeriod(days = numDaysToSubtract))
+            println("Date: $date")
+            val hebrew = HebrewLocalDate.STARTING_DATE_HEBREW
+            val expectedNewMonth = hebrew.month.previousMonth
+            val expectedNewYear = hebrew.year - 1
+            val daysInJewishMonth = JewishDate.getDaysInJewishMonth(expectedNewMonth, expectedNewYear)
+            println("Days in jewish month: $daysInJewishMonth")
+            assertEquals(
+                HebrewLocalDate(
+                    expectedNewYear,
+                    expectedNewMonth,
+                    daysInJewishMonth - numDaysToSubtract + hebrew.dayOfMonth*//*include starting day of old year*//*
             ), date.toHebrewDate()
         )
     }

--- a/composeApp/src/test/kotlin/hebrewcalendar/ConvertBetweenGregorianAndHebrewTest.kt
+++ b/composeApp/src/test/kotlin/hebrewcalendar/ConvertBetweenGregorianAndHebrewTest.kt
@@ -1,6 +1,7 @@
 package hebrewcalendar
 
 import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.number
 import kotlinx.datetime.plus
 import sternbach.software.kosherkotlin.hebrewcalendar.HebrewLocalDate.Companion.toHebrewDate
 import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate.Companion.daysInJewishYear
@@ -141,9 +142,9 @@ class ConvertBetweenGregorianAndHebrewTest {
         val distantFutureJewishDate =
             com.kosherjava.zmanim.hebrewcalendar.JewishDate(
                 LocalDate.of(
-                    newGregorianDate.year,
-                    newGregorianDate.month,
-                    newGregorianDate.dayOfMonth
+                    /* year = */ newGregorianDate.year,
+                    /* month = */ newGregorianDate.month.number,
+                    /* dayOfMonth = */ newGregorianDate.dayOfMonth
                 )
             ) //java.time.LocalDate.of(2239, Month.SEPTEMBER, 30) == 6000-1-1 hebrew, but takes too long to complete
         var kotlinCurrentJewishDate = HebrewLocalDate(
@@ -170,7 +171,7 @@ class ConvertBetweenGregorianAndHebrewTest {
 
             val kotlinGregorian = kotlinCurrentJewishDate.toLocalDateGregorian()
             assertEquals(javaCurrentJewishDate.gregorianYear, kotlinGregorian.year)
-            assertEquals(javaCurrentJewishDate.gregorianMonth + 1, kotlinGregorian.month.value)
+            assertEquals(javaCurrentJewishDate.gregorianMonth + 1, kotlinGregorian.month.number)
             assertEquals(javaCurrentJewishDate.gregorianDayOfMonth, kotlinGregorian.dayOfMonth)
 
             javaCurrentJewishDate.forward(Calendar.DATE, 1);

--- a/composeApp/src/test/kotlin/hebrewcalendar/RegressionTest.kt
+++ b/composeApp/src/test/kotlin/hebrewcalendar/RegressionTest.kt
@@ -8,11 +8,10 @@ import kotlinx.datetime.LocalTime
 import kotlinx.datetime.Month
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.number
 import kotlinx.datetime.plus
 import kotlinx.datetime.toInstant
-import kotlinx.datetime.toJavaInstant
 import kotlinx.datetime.toJavaZoneId
-import kotlinx.datetime.toKotlinInstant
 import kotlinx.datetime.toKotlinLocalDate
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.datetime.until
@@ -37,6 +36,8 @@ import java.util.Calendar
 import java.util.Date
 import java.util.stream.Collectors
 import java.util.stream.LongStream
+import kotlin.time.toJavaInstant
+import kotlin.time.toKotlinInstant
 
 class RegressionTest {
     companion object {
@@ -76,9 +77,9 @@ class RegressionTest {
 
         val kotlinDate = startingDateGregorian.atStartOfDayIn(TimeZone.UTC)
         val javaDate = java.time.LocalDate.of(
-            startingDateGregorian.year,
-            startingDateGregorian.month,
-            startingDateGregorian.dayOfMonth
+            /* year = */ startingDateGregorian.year,
+            /* month = */ startingDateGregorian.month.number,
+            /* dayOfMonth = */ startingDateGregorian.dayOfMonth
         )
         val allDays = LongStream
             .range(0, kotlinDate.until(YEAR_6000_INSTANT, DateTimeUnit.DAY, TimeZone.UTC))

--- a/composeApp/src/test/kotlin/hebrewcalendar/UT_DaysInJewishMonth.kt
+++ b/composeApp/src/test/kotlin/hebrewcalendar/UT_DaysInJewishMonth.kt
@@ -3,9 +3,9 @@
  */
 package hebrewcalendar
 
-import org.junit.Assert
-import org.junit.Assert.*
-import org.junit.Before
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate
 

--- a/composeApp/src/test/kotlin/hebrewcalendar/UT_GregorianDateNavigation.kt
+++ b/composeApp/src/test/kotlin/hebrewcalendar/UT_GregorianDateNavigation.kt
@@ -9,7 +9,8 @@ import org.junit.Assert
 import org.junit.Test
 import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate
 import java.time.ZoneId
-import java.util.*
+import java.util.Calendar
+import java.util.TimeZone
 
 /**
  * Checks that we can roll forward & backward the gregorian dates...

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
 
-kotlin = "1.9.10"
-agp = "8.1.2"
-compose = "1.5.1"
-androidx-appcompat = "1.6.1"
-androidx-activityCompose = "1.7.2"
-compose-uitooling = "1.5.1"
-napier = "2.6.1"
-buildConfig = "4.1.1"
-kotlinx-coroutines = "1.7.3"
+kotlin = "2.3.0"
+agp = "8.13.2"
+compose = "1.9.3"
+androidx-appcompat = "1.7.1"
+androidx-activityCompose = "1.12.2"
+compose-uitooling = "1.10.0"
+napier = "2.7.1"
+buildConfig = "6.0.7"
+kotlinx-coroutines = "1.10.2"
 ktor = "2.3.5"
-kotlinx-serialization = "1.6.0"
-kotlinx-datetime = "0.4.1"
+kotlinx-serialization = "1.9.0"
+kotlinx-datetime = "0.7.1"
 
 [libraries]
 
@@ -34,3 +34,4 @@ compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 buildConfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildConfig" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-
+#Tue Jan 06 15:54:39 IST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR modernizes the project build and dependencies.

### Changes included
- Bumped various library versions, including Kotlin, Android Gradle Plugin, and Compose
- Upgraded Gradle wrapper to 9.2.0
- Updated Android `compileSdk` to 36 and `targetSdk` to 35
- Added the Compose compiler plugin
- Set JVM toolchain to JDK 17
- Ignored the `.kotlin/` directory

### Code cleanup
- Replaced `kotlinx.datetime.Clock` / `Instant` usage with `kotlin.time.Clock` / `Instant`
- Cleaned up unused imports

### Tests
- Updated tests to use `month.number` instead of deprecated `month` / `month.value`

No functional changes were introduced beyond dependency and API modernization.
Build and tests were verified locally.


Unit tests status:
<img width="457" height="602" alt="Screenshot 2026-01-06 at 16 35 31" src="https://github.com/user-attachments/assets/69b0fcfc-0546-40a9-b468-b7a075dfd1f3" />
