### PR TITLE
Fix incorrect parsha calculation due to HebrewMonth iteration logic

### DIFF
--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/HebrewMonth.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/HebrewMonth.kt
@@ -1,6 +1,7 @@
 package sternbach.software.kosherkotlin.hebrewcalendar;
 
 import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate.Companion.isJewishLeapYear
+import kotlin.math.absoluteValue
 
 enum class HebrewMonth(val value: Int) : Comparable<HebrewMonth> {
     /**
@@ -102,9 +103,9 @@ enum class HebrewMonth(val value: Int) : Comparable<HebrewMonth> {
     val nextMonth get() = getMonthForValue(value + 1)
 
     fun isLastMonthInYear(jewishYear: Long, tishreiBased: Boolean = true) =
-        if (tishreiBased) this == ELUL
+        if(tishreiBased) this == ELUL
         else
-            if (jewishYear.isJewishLeapYear) this == ADAR_II
+            if(jewishYear.isJewishLeapYear) this == ADAR_II
             else this == ADAR
 
     fun isFirstMonthInYear(tishreiBased: Boolean = true) =
@@ -124,7 +125,7 @@ enum class HebrewMonth(val value: Int) : Comparable<HebrewMonth> {
         ) null /*get next month after last month?! we would spill over to the next year*/
         else
             if (this == ADAR)
-                if (jewishYear.isJewishLeapYear) ADAR_II
+                if(jewishYear.isJewishLeapYear) ADAR_II
                 else NISSAN
             else nextMonth
 
@@ -151,7 +152,7 @@ enum class HebrewMonth(val value: Int) : Comparable<HebrewMonth> {
 
     class HebrewMonthRange(
         override val start: HebrewMonth,
-        override val endInclusive: HebrewMonth,
+        override val endInclusive: HebrewMonth
     ) : ClosedRange<HebrewMonth>, Iterable<HebrewMonth> {
         override fun iterator(): Iterator<HebrewMonth> = object : Iterator<HebrewMonth> {
             private var next = start
@@ -171,31 +172,17 @@ enum class HebrewMonth(val value: Int) : Comparable<HebrewMonth> {
 
     companion object {
         /**
-         * Returns the [HebrewMonth] for the given numeric value, where 1 corresponds to [NISSAN]
-         * and 13 corresponds to [ADAR_II].
-         *
-         * Values outside the range 1..13 are wrapped cyclically using modulo arithmetic.
-         * This means the sequence is treated as circular:
-         * - 0 returns [ADAR_II]
-         * - -1 returns [ADAR]
-         * - 14 returns [NISSAN]
-         * - 15 returns [IYAR]
-         *
-         * This behavior ensures correct navigation when moving forward or backward across
-         * month boundaries (e.g., for [previousMonth] / [nextMonth]).
-         *
-         * @param value any integer (positive, zero, or negative)
-         * @return the corresponding [HebrewMonth] after wrapping
-         */
+         * Returns the HebrewMonth for the given value, with 1 being [NISSAN] and 13 being [ADAR_II].
+         * @param value from 1 to 13. Values outside this range will be wrapped.
+         * */
         fun getMonthForValue(value: Int): HebrewMonth {
-            val values = entries.toTypedArray()
-            val index = (value - 1).mod(values.size)
-            return values[index]
+            val values = values()
+            return values[((value - 1) % values.size).absoluteValue]
         }
 
         /**
          * Converts the [NISSAN] based constants used by this class to numeric month starting from
-         * [TISHREI]. This is required for Molad calculations.
+         * [TISHREI]. This is required for Molad claculations.
          *
          * @param jewishYear
          * The Jewish year
@@ -205,12 +192,10 @@ enum class HebrewMonth(val value: Int) : Comparable<HebrewMonth> {
          */
         fun getTishreiBasedValue(nissanBasedValue: Int, jewishYear: Int): Int =
             getTishreiBasedValue(nissanBasedValue, jewishYear.toLong())
-
         fun getTishreiBasedValue(nissanBasedValue: Int, jewishYear: Long): Int =
             1 +
-                    if (jewishYear.isJewishLeapYear) (nissanBasedValue + 6) % 13
+                    if(jewishYear.isJewishLeapYear) (nissanBasedValue + 6) % 13
                     else (nissanBasedValue + 5) % 12
-
         /**
          * Interpolates this [month]
          * */

--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/HebrewMonth.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/HebrewMonth.kt
@@ -1,7 +1,6 @@
 package sternbach.software.kosherkotlin.hebrewcalendar;
 
 import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate.Companion.isJewishLeapYear
-import kotlin.math.absoluteValue
 
 enum class HebrewMonth(val value: Int) : Comparable<HebrewMonth> {
     /**
@@ -103,9 +102,9 @@ enum class HebrewMonth(val value: Int) : Comparable<HebrewMonth> {
     val nextMonth get() = getMonthForValue(value + 1)
 
     fun isLastMonthInYear(jewishYear: Long, tishreiBased: Boolean = true) =
-        if(tishreiBased) this == ELUL
+        if (tishreiBased) this == ELUL
         else
-            if(jewishYear.isJewishLeapYear) this == ADAR_II
+            if (jewishYear.isJewishLeapYear) this == ADAR_II
             else this == ADAR
 
     fun isFirstMonthInYear(tishreiBased: Boolean = true) =
@@ -125,7 +124,7 @@ enum class HebrewMonth(val value: Int) : Comparable<HebrewMonth> {
         ) null /*get next month after last month?! we would spill over to the next year*/
         else
             if (this == ADAR)
-                if(jewishYear.isJewishLeapYear) ADAR_II
+                if (jewishYear.isJewishLeapYear) ADAR_II
                 else NISSAN
             else nextMonth
 
@@ -152,7 +151,7 @@ enum class HebrewMonth(val value: Int) : Comparable<HebrewMonth> {
 
     class HebrewMonthRange(
         override val start: HebrewMonth,
-        override val endInclusive: HebrewMonth
+        override val endInclusive: HebrewMonth,
     ) : ClosedRange<HebrewMonth>, Iterable<HebrewMonth> {
         override fun iterator(): Iterator<HebrewMonth> = object : Iterator<HebrewMonth> {
             private var next = start
@@ -172,17 +171,31 @@ enum class HebrewMonth(val value: Int) : Comparable<HebrewMonth> {
 
     companion object {
         /**
-         * Returns the HebrewMonth for the given value, with 1 being [NISSAN] and 13 being [ADAR_II].
-         * @param value from 1 to 13. Values outside this range will be wrapped.
-         * */
+         * Returns the [HebrewMonth] for the given numeric value, where 1 corresponds to [NISSAN]
+         * and 13 corresponds to [ADAR_II].
+         *
+         * Values outside the range 1..13 are wrapped cyclically using modulo arithmetic.
+         * This means the sequence is treated as circular:
+         * - 0 returns [ADAR_II]
+         * - -1 returns [ADAR]
+         * - 14 returns [NISSAN]
+         * - 15 returns [IYAR]
+         *
+         * This behavior ensures correct navigation when moving forward or backward across
+         * month boundaries (e.g., for [previousMonth] / [nextMonth]).
+         *
+         * @param value any integer (positive, zero, or negative)
+         * @return the corresponding [HebrewMonth] after wrapping
+         */
         fun getMonthForValue(value: Int): HebrewMonth {
-            val values = values()
-            return values[((value - 1) % values.size).absoluteValue]
+            val values = entries.toTypedArray()
+            val index = (value - 1).mod(values.size)
+            return values[index]
         }
 
         /**
          * Converts the [NISSAN] based constants used by this class to numeric month starting from
-         * [TISHREI]. This is required for Molad claculations.
+         * [TISHREI]. This is required for Molad calculations.
          *
          * @param jewishYear
          * The Jewish year
@@ -192,10 +205,12 @@ enum class HebrewMonth(val value: Int) : Comparable<HebrewMonth> {
          */
         fun getTishreiBasedValue(nissanBasedValue: Int, jewishYear: Int): Int =
             getTishreiBasedValue(nissanBasedValue, jewishYear.toLong())
+
         fun getTishreiBasedValue(nissanBasedValue: Int, jewishYear: Long): Int =
             1 +
-                    if(jewishYear.isJewishLeapYear) (nissanBasedValue + 6) % 13
+                    if (jewishYear.isJewishLeapYear) (nissanBasedValue + 6) % 13
                     else (nissanBasedValue + 5) % 12
+
         /**
          * Interpolates this [month]
          * */

--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/JewishDate.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/JewishDate.kt
@@ -73,7 +73,6 @@ open class JewishDate : Comparable<JewishDate> {
         val conjunctionParts = (molad - conjunctionDay * CHALAKIM_PER_DAY.toLong()).toInt()
         setMoladTime(conjunctionParts)
     }
-
     /**
      * Creates a Jewish date based on a Jewish year, month and day of month.
      *
@@ -94,17 +93,10 @@ open class JewishDate : Comparable<JewishDate> {
     constructor(hebrewYear: Long, hebrewMonth: HebrewMonth, hebrewDayOfMonth: Int) {
         setJewishDate(hebrewYear, hebrewMonth, hebrewDayOfMonth)
     }
-
-    constructor(hebrewYear: Int, hebrewMonth: Int, hebrewDayOfMonth: Int) : this(
-        hebrewYear,
-        HebrewMonth.getMonthForValue(hebrewMonth),
-        hebrewDayOfMonth
-    )
-
+    constructor(hebrewYear: Int, hebrewMonth: Int, hebrewDayOfMonth: Int) : this(hebrewYear, HebrewMonth.getMonthForValue(hebrewMonth), hebrewDayOfMonth)
     constructor(localDate: LocalDate) {
         setDate(localDate)
     }
-
     constructor(hebrewLocalDate: HebrewLocalDate) {
         setJewishDate(hebrewLocalDate)
     }
@@ -334,7 +326,6 @@ open class JewishDate : Comparable<JewishDate> {
         hebrewLocalDate.month,
         hebrewLocalDate.dayOfMonth
     )
-
     fun setJewishDate(year: Long, month: HebrewMonth, dayOfMonth: Int): JewishDate {
         setJewishDate(year, month, dayOfMonth, 0, 0, 0)
         return this
@@ -384,7 +375,7 @@ open class JewishDate : Comparable<JewishDate> {
         moladHours = hours
         moladMinutes = minutes
         moladChalakim = chalakim
-        gregorianLocalDate = date.toLocalDateGregorian()
+        gregorianLocalDate = date.toLocalDateGregorian() 
         return this
     }
 
@@ -457,7 +448,6 @@ open class JewishDate : Comparable<JewishDate> {
                     }
                 }
             }
-
             DateTimeUnit.MONTH -> forwardJewishMonth(amount)
             DateTimeUnit.YEAR -> jewishYear = hebrewLocalDate.year + amount
             else -> {
@@ -513,16 +503,10 @@ open class JewishDate : Comparable<JewishDate> {
         // change Jewish date
         hebrewLocalDate = if (hebrewLocalDate.dayOfMonth == 1) { // if first day of the Jewish month
             when (hebrewLocalDate.month) {
-                HebrewMonth.NISSAN -> HebrewLocalDate(
-                    hebrewLocalDate.year,
-                    getLastMonthOfJewishYear(hebrewLocalDate.year),
-                    daysInJewishMonth
-                )
-
+                HebrewMonth.NISSAN -> HebrewLocalDate(hebrewLocalDate.year, getLastMonthOfJewishYear(hebrewLocalDate.year), daysInJewishMonth)
                 HebrewMonth.TISHREI -> { // if Rosh Hashana
                     HebrewLocalDate(hebrewLocalDate.year - 1, hebrewLocalDate.month.previousMonth, daysInJewishMonth)
                 }
-
                 else -> HebrewLocalDate(hebrewLocalDate.year, hebrewLocalDate.month.previousMonth, daysInJewishMonth)
             }
         } else {
@@ -562,16 +546,11 @@ open class JewishDate : Comparable<JewishDate> {
          * (in the current implementation) if a year of < [HebrewLocalDate.STARTING_DATE_HEBREW]
          * (Tishrei 1, 0002/Sep. 6, 1 AD in current implementation) is passed in. TODO
          */
-        set(value) {
-            setJewishDate(value, hebrewLocalDate.month, hebrewLocalDate.dayOfMonth)
-        }
+        set(value) { setJewishDate(value, hebrewLocalDate.month, hebrewLocalDate.dayOfMonth) }
 
     var jewishMonth: HebrewMonth
-        set(value) {
-            setJewishDate(hebrewLocalDate.year, value, hebrewLocalDate.dayOfMonth)
-        }
+        set(value) { setJewishDate(hebrewLocalDate.year, value, hebrewLocalDate.dayOfMonth) }
         get() = hebrewLocalDate.month
-
     /**
      * The Jewish day of month.
      */
@@ -586,11 +565,10 @@ open class JewishDate : Comparable<JewishDate> {
          * **Note:** If [jewishMonth] does not have [dayOfMonth] days in the current [jewishYear], this setter will
          * correct the value instead of throwing an error.
          * */
-        set(dayOfMonth) {
-            setJewishDate(hebrewLocalDate.year, hebrewLocalDate.month, dayOfMonth)
-        }
+        set(dayOfMonth) { setJewishDate(hebrewLocalDate.year, hebrewLocalDate.month, dayOfMonth) }
 
     var gregorianYear
+
         /**
          * sets the Gregorian year.
          *
@@ -602,9 +580,7 @@ open class JewishDate : Comparable<JewishDate> {
          * **Note:** This setter will correct the [dayOfMonth] if passed in an invalid number given the [year] and [month]
          * (e.g. February 29 in a leap year)
          */
-        set(value) {
-            setGregorianDate(value, gregorianLocalDate.monthNumber, gregorianLocalDate.dayOfMonth)
-        }
+        set(value) { setGregorianDate(value, gregorianLocalDate.monthNumber, gregorianLocalDate.dayOfMonth) }
         get() = gregorianLocalDate.year
 
     var gregorianMonth
@@ -620,9 +596,7 @@ open class JewishDate : Comparable<JewishDate> {
          * **Note:** This setter will correct the [value] if passed in an invalid number given the [gregorianYear] and [gregorianMonth]
          * (e.g. February 29 in a leap year)
          */
-        set(value) {
-            setGregorianDate(gregorianLocalDate.year, value, gregorianLocalDate.dayOfMonth)
-        }
+        set(value) { setGregorianDate(gregorianLocalDate.year, value, gregorianLocalDate.dayOfMonth) }
         get() = gregorianLocalDate.monthNumber
 
     var gregorianDayOfMonth
@@ -638,9 +612,7 @@ open class JewishDate : Comparable<JewishDate> {
          * **Note:** This setter will correct the [value] if passed in an invalid number given the [gregorianYear] and [gregorianMonth]
          * (e.g. February 29 in a leap year)
          */
-        set(value) {
-            setGregorianDate(gregorianLocalDate.year, gregorianLocalDate.monthNumber, value)
-        }
+        set(value) { setGregorianDate(gregorianLocalDate.year, gregorianLocalDate.monthNumber, value) }
         get() = gregorianLocalDate.dayOfMonth
 
 
@@ -658,11 +630,7 @@ open class JewishDate : Comparable<JewishDate> {
         return this
     }
 
-    val Int.lastDayOfGregorianMonth
-        get() = getLastDayOfGregorianMonth(
-            this,
-            gregorianLocalDate.year
-        ) //TODO is this an easily-abusable/confusing API because it is scoped to the current instance's year?
+    val Int.lastDayOfGregorianMonth get() = getLastDayOfGregorianMonth(this, gregorianLocalDate.year) //TODO is this an easily-abusable/confusing API because it is scoped to the current instance's year?
 
     /**
      * A method that creates a [deep copy](http://en.wikipedia.org/wiki/Object_copy#Deep_copy) of the object.
@@ -682,7 +650,7 @@ open class JewishDate : Comparable<JewishDate> {
     fun copy(
         hebrewYear: Long = hebrewLocalDate.year,
         month: HebrewMonth = hebrewLocalDate.month,
-        hebrewDayOfMonth: Int = hebrewLocalDate.dayOfMonth,
+        hebrewDayOfMonth: Int = hebrewLocalDate.dayOfMonth
     ): JewishDate = JewishDate(hebrewYear, month, hebrewDayOfMonth)
 
     /**
@@ -863,9 +831,7 @@ open class JewishDate : Comparable<JewishDate> {
          * @param moladParts the molad parts
          * @return the number of elapsed days in the JewishCalendar adjusted for the 4 dechiyos.
          */
-        private fun addDechiyos(year: Int, moladDay: Int, moladParts: Int): Int =
-            addDechiyos(year.toLong(), moladDay.toLong(), moladParts).toInt()
-
+        private fun addDechiyos(year: Int, moladDay: Int, moladParts: Int): Int = addDechiyos(year.toLong(), moladDay.toLong(), moladParts).toInt()
         private fun addDechiyos(year: Long, moladDay: Long, moladParts: Int): Long {
             var roshHashanaDay = moladDay // if no dechiyos
             // delay Rosh Hashana for the dechiyos of the Molad - new moon 1 - Molad Zaken, 2- GaTRaD 3- BeTuTaKFoT
@@ -945,7 +911,7 @@ open class JewishDate : Comparable<JewishDate> {
         private fun validateJewishDate(
             hours: Int,
             minutes: Int,
-            chalakim: Int,
+            chalakim: Int
         ) {
             require(!(hours < 0 || hours > 23)) { "Hours < 0 or > 23 can't be set. $hours is invalid." }
             require(!(minutes < 0 || minutes > 59)) { "Minutes < 0 or > 59 can't be set. $minutes is invalid." }
@@ -1023,7 +989,7 @@ open class JewishDate : Comparable<JewishDate> {
         private fun moladToAbsDate(chalakim: Long): Int = (chalakim / CHALAKIM_PER_DAY).toInt() + HebrewLocalDate.JEWISH_EPOCH
 
         /**
-         * Returns the number of days from Rosh Hashana of the date passed in, to the full date passed in.
+         * returns the number of days from Rosh Hashana of the date passed in, to the full date passed in.
          *
          * @param year
          * the Jewish year
@@ -1035,23 +1001,14 @@ open class JewishDate : Comparable<JewishDate> {
          */
         fun getDaysSinceStartOfJewishYear(year: Long, month: HebrewMonth, dayOfMonth: Int): Int {
             var elapsedDays = dayOfMonth
-
             // Before Tishrei (from Nissan to Tishrei), add days in prior months
-            if (month.value < HebrewMonth.TISHREI.value) {
+            if (month < HebrewMonth.TISHREI) {
                 // this year before and after Nisan.
-                for (m in HebrewMonth.TISHREI.value..getLastMonthOfJewishYear(year).value) {
-                    elapsedDays += getDaysInJewishMonth(HebrewMonth.getMonthForValue(m), year)
-                }
-                for (m in HebrewMonth.NISSAN.value until month.value) {
-                    elapsedDays += getDaysInJewishMonth(HebrewMonth.getMonthForValue(m), year)
-                }
-            } else {
-                // Add days in prior months this year
-                for (m in HebrewMonth.TISHREI.value until month.value) {
-                    elapsedDays += getDaysInJewishMonth(HebrewMonth.getMonthForValue(m), year)
-                }
+                for (m in HebrewMonth.TISHREI..getLastMonthOfJewishYear(year)) elapsedDays += getDaysInJewishMonth(m, year)
+                for (m in HebrewMonth.NISSAN until month) elapsedDays += getDaysInJewishMonth(m, year)
+            } else { // Add days in prior months this year
+                for (m in HebrewMonth.TISHREI until month) elapsedDays += getDaysInJewishMonth(m, year)
             }
-
             return elapsedDays
         }
     }

--- a/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/JewishDate.kt
+++ b/composeApp/src/commonMain/kotlin/sternbach/software/kosherkotlin/hebrewcalendar/JewishDate.kt
@@ -73,6 +73,7 @@ open class JewishDate : Comparable<JewishDate> {
         val conjunctionParts = (molad - conjunctionDay * CHALAKIM_PER_DAY.toLong()).toInt()
         setMoladTime(conjunctionParts)
     }
+
     /**
      * Creates a Jewish date based on a Jewish year, month and day of month.
      *
@@ -93,10 +94,17 @@ open class JewishDate : Comparable<JewishDate> {
     constructor(hebrewYear: Long, hebrewMonth: HebrewMonth, hebrewDayOfMonth: Int) {
         setJewishDate(hebrewYear, hebrewMonth, hebrewDayOfMonth)
     }
-    constructor(hebrewYear: Int, hebrewMonth: Int, hebrewDayOfMonth: Int) : this(hebrewYear, HebrewMonth.getMonthForValue(hebrewMonth), hebrewDayOfMonth)
+
+    constructor(hebrewYear: Int, hebrewMonth: Int, hebrewDayOfMonth: Int) : this(
+        hebrewYear,
+        HebrewMonth.getMonthForValue(hebrewMonth),
+        hebrewDayOfMonth
+    )
+
     constructor(localDate: LocalDate) {
         setDate(localDate)
     }
+
     constructor(hebrewLocalDate: HebrewLocalDate) {
         setJewishDate(hebrewLocalDate)
     }
@@ -326,6 +334,7 @@ open class JewishDate : Comparable<JewishDate> {
         hebrewLocalDate.month,
         hebrewLocalDate.dayOfMonth
     )
+
     fun setJewishDate(year: Long, month: HebrewMonth, dayOfMonth: Int): JewishDate {
         setJewishDate(year, month, dayOfMonth, 0, 0, 0)
         return this
@@ -375,7 +384,7 @@ open class JewishDate : Comparable<JewishDate> {
         moladHours = hours
         moladMinutes = minutes
         moladChalakim = chalakim
-        gregorianLocalDate = date.toLocalDateGregorian() 
+        gregorianLocalDate = date.toLocalDateGregorian()
         return this
     }
 
@@ -448,6 +457,7 @@ open class JewishDate : Comparable<JewishDate> {
                     }
                 }
             }
+
             DateTimeUnit.MONTH -> forwardJewishMonth(amount)
             DateTimeUnit.YEAR -> jewishYear = hebrewLocalDate.year + amount
             else -> {
@@ -503,10 +513,16 @@ open class JewishDate : Comparable<JewishDate> {
         // change Jewish date
         hebrewLocalDate = if (hebrewLocalDate.dayOfMonth == 1) { // if first day of the Jewish month
             when (hebrewLocalDate.month) {
-                HebrewMonth.NISSAN -> HebrewLocalDate(hebrewLocalDate.year, getLastMonthOfJewishYear(hebrewLocalDate.year), daysInJewishMonth)
+                HebrewMonth.NISSAN -> HebrewLocalDate(
+                    hebrewLocalDate.year,
+                    getLastMonthOfJewishYear(hebrewLocalDate.year),
+                    daysInJewishMonth
+                )
+
                 HebrewMonth.TISHREI -> { // if Rosh Hashana
                     HebrewLocalDate(hebrewLocalDate.year - 1, hebrewLocalDate.month.previousMonth, daysInJewishMonth)
                 }
+
                 else -> HebrewLocalDate(hebrewLocalDate.year, hebrewLocalDate.month.previousMonth, daysInJewishMonth)
             }
         } else {
@@ -546,11 +562,16 @@ open class JewishDate : Comparable<JewishDate> {
          * (in the current implementation) if a year of < [HebrewLocalDate.STARTING_DATE_HEBREW]
          * (Tishrei 1, 0002/Sep. 6, 1 AD in current implementation) is passed in. TODO
          */
-        set(value) { setJewishDate(value, hebrewLocalDate.month, hebrewLocalDate.dayOfMonth) }
+        set(value) {
+            setJewishDate(value, hebrewLocalDate.month, hebrewLocalDate.dayOfMonth)
+        }
 
     var jewishMonth: HebrewMonth
-        set(value) { setJewishDate(hebrewLocalDate.year, value, hebrewLocalDate.dayOfMonth) }
+        set(value) {
+            setJewishDate(hebrewLocalDate.year, value, hebrewLocalDate.dayOfMonth)
+        }
         get() = hebrewLocalDate.month
+
     /**
      * The Jewish day of month.
      */
@@ -565,10 +586,11 @@ open class JewishDate : Comparable<JewishDate> {
          * **Note:** If [jewishMonth] does not have [dayOfMonth] days in the current [jewishYear], this setter will
          * correct the value instead of throwing an error.
          * */
-        set(dayOfMonth) { setJewishDate(hebrewLocalDate.year, hebrewLocalDate.month, dayOfMonth) }
+        set(dayOfMonth) {
+            setJewishDate(hebrewLocalDate.year, hebrewLocalDate.month, dayOfMonth)
+        }
 
     var gregorianYear
-
         /**
          * sets the Gregorian year.
          *
@@ -580,7 +602,9 @@ open class JewishDate : Comparable<JewishDate> {
          * **Note:** This setter will correct the [dayOfMonth] if passed in an invalid number given the [year] and [month]
          * (e.g. February 29 in a leap year)
          */
-        set(value) { setGregorianDate(value, gregorianLocalDate.monthNumber, gregorianLocalDate.dayOfMonth) }
+        set(value) {
+            setGregorianDate(value, gregorianLocalDate.monthNumber, gregorianLocalDate.dayOfMonth)
+        }
         get() = gregorianLocalDate.year
 
     var gregorianMonth
@@ -596,7 +620,9 @@ open class JewishDate : Comparable<JewishDate> {
          * **Note:** This setter will correct the [value] if passed in an invalid number given the [gregorianYear] and [gregorianMonth]
          * (e.g. February 29 in a leap year)
          */
-        set(value) { setGregorianDate(gregorianLocalDate.year, value, gregorianLocalDate.dayOfMonth) }
+        set(value) {
+            setGregorianDate(gregorianLocalDate.year, value, gregorianLocalDate.dayOfMonth)
+        }
         get() = gregorianLocalDate.monthNumber
 
     var gregorianDayOfMonth
@@ -612,7 +638,9 @@ open class JewishDate : Comparable<JewishDate> {
          * **Note:** This setter will correct the [value] if passed in an invalid number given the [gregorianYear] and [gregorianMonth]
          * (e.g. February 29 in a leap year)
          */
-        set(value) { setGregorianDate(gregorianLocalDate.year, gregorianLocalDate.monthNumber, value) }
+        set(value) {
+            setGregorianDate(gregorianLocalDate.year, gregorianLocalDate.monthNumber, value)
+        }
         get() = gregorianLocalDate.dayOfMonth
 
 
@@ -630,7 +658,11 @@ open class JewishDate : Comparable<JewishDate> {
         return this
     }
 
-    val Int.lastDayOfGregorianMonth get() = getLastDayOfGregorianMonth(this, gregorianLocalDate.year) //TODO is this an easily-abusable/confusing API because it is scoped to the current instance's year?
+    val Int.lastDayOfGregorianMonth
+        get() = getLastDayOfGregorianMonth(
+            this,
+            gregorianLocalDate.year
+        ) //TODO is this an easily-abusable/confusing API because it is scoped to the current instance's year?
 
     /**
      * A method that creates a [deep copy](http://en.wikipedia.org/wiki/Object_copy#Deep_copy) of the object.
@@ -650,7 +682,7 @@ open class JewishDate : Comparable<JewishDate> {
     fun copy(
         hebrewYear: Long = hebrewLocalDate.year,
         month: HebrewMonth = hebrewLocalDate.month,
-        hebrewDayOfMonth: Int = hebrewLocalDate.dayOfMonth
+        hebrewDayOfMonth: Int = hebrewLocalDate.dayOfMonth,
     ): JewishDate = JewishDate(hebrewYear, month, hebrewDayOfMonth)
 
     /**
@@ -831,7 +863,9 @@ open class JewishDate : Comparable<JewishDate> {
          * @param moladParts the molad parts
          * @return the number of elapsed days in the JewishCalendar adjusted for the 4 dechiyos.
          */
-        private fun addDechiyos(year: Int, moladDay: Int, moladParts: Int): Int = addDechiyos(year.toLong(), moladDay.toLong(), moladParts).toInt()
+        private fun addDechiyos(year: Int, moladDay: Int, moladParts: Int): Int =
+            addDechiyos(year.toLong(), moladDay.toLong(), moladParts).toInt()
+
         private fun addDechiyos(year: Long, moladDay: Long, moladParts: Int): Long {
             var roshHashanaDay = moladDay // if no dechiyos
             // delay Rosh Hashana for the dechiyos of the Molad - new moon 1 - Molad Zaken, 2- GaTRaD 3- BeTuTaKFoT
@@ -911,7 +945,7 @@ open class JewishDate : Comparable<JewishDate> {
         private fun validateJewishDate(
             hours: Int,
             minutes: Int,
-            chalakim: Int
+            chalakim: Int,
         ) {
             require(!(hours < 0 || hours > 23)) { "Hours < 0 or > 23 can't be set. $hours is invalid." }
             require(!(minutes < 0 || minutes > 59)) { "Minutes < 0 or > 59 can't be set. $minutes is invalid." }
@@ -989,7 +1023,7 @@ open class JewishDate : Comparable<JewishDate> {
         private fun moladToAbsDate(chalakim: Long): Int = (chalakim / CHALAKIM_PER_DAY).toInt() + HebrewLocalDate.JEWISH_EPOCH
 
         /**
-         * returns the number of days from Rosh Hashana of the date passed in, to the full date passed in.
+         * Returns the number of days from Rosh Hashana of the date passed in, to the full date passed in.
          *
          * @param year
          * the Jewish year
@@ -1001,14 +1035,23 @@ open class JewishDate : Comparable<JewishDate> {
          */
         fun getDaysSinceStartOfJewishYear(year: Long, month: HebrewMonth, dayOfMonth: Int): Int {
             var elapsedDays = dayOfMonth
+
             // Before Tishrei (from Nissan to Tishrei), add days in prior months
-            if (month < HebrewMonth.TISHREI) {
+            if (month.value < HebrewMonth.TISHREI.value) {
                 // this year before and after Nisan.
-                for (m in HebrewMonth.TISHREI..getLastMonthOfJewishYear(year)) elapsedDays += getDaysInJewishMonth(m, year)
-                for (m in HebrewMonth.NISSAN until month) elapsedDays += getDaysInJewishMonth(m, year)
-            } else { // Add days in prior months this year
-                for (m in HebrewMonth.TISHREI until month) elapsedDays += getDaysInJewishMonth(m, year)
+                for (m in HebrewMonth.TISHREI.value..getLastMonthOfJewishYear(year).value) {
+                    elapsedDays += getDaysInJewishMonth(HebrewMonth.getMonthForValue(m), year)
+                }
+                for (m in HebrewMonth.NISSAN.value until month.value) {
+                    elapsedDays += getDaysInJewishMonth(HebrewMonth.getMonthForValue(m), year)
+                }
+            } else {
+                // Add days in prior months this year
+                for (m in HebrewMonth.TISHREI.value until month.value) {
+                    elapsedDays += getDaysInJewishMonth(HebrewMonth.getMonthForValue(m), year)
+                }
             }
+
             return elapsedDays
         }
     }

--- a/composeApp/src/test/kotlin/hebrewcalendar/JewishCalendarParshaRegressionTest.kt
+++ b/composeApp/src/test/kotlin/hebrewcalendar/JewishCalendarParshaRegressionTest.kt
@@ -1,0 +1,136 @@
+package hebrewcalendar
+
+import kotlinx.datetime.LocalDate
+import sternbach.software.kosherkotlin.hebrewcalendar.HebrewDateFormatter
+import sternbach.software.kosherkotlin.hebrewcalendar.HebrewMonth
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishCalendar
+import sternbach.software.kosherkotlin.hebrewcalendar.JewishDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class JewishCalendarParshaRegressionTest {
+
+    @Test
+    fun `18 Nissan 5786 should return Shmini`() {
+        val calendar = JewishCalendar(
+            LocalDate(year = 2026, monthNumber = 4, dayOfMonth = 5),
+        )
+
+        assertEquals(
+            JewishCalendar.Parsha.SHMINI,
+            calendar.upcomingParshah,
+        )
+    }
+
+    @Test
+    fun `one week later should return Tazria Metzora`() {
+        val calendar = JewishCalendar(
+            LocalDate(year = 2026, monthNumber = 4, dayOfMonth = 12),
+        )
+
+        assertEquals(
+            JewishCalendar.Parsha.TAZRIA_METZORA,
+            calendar.upcomingParshah,
+        )
+    }
+
+    @Test
+    fun `formatParsha should match Shmini on 18 Nissan 5786`() {
+        val calendar = JewishCalendar(
+            LocalDate(year = 2026, monthNumber = 4, dayOfMonth = 11),
+        )
+        val formatter = HebrewDateFormatter()
+
+        assertEquals(
+            "Shmini",
+            formatter.formatParsha(calendar),
+        )
+    }
+
+    @Test
+    fun `formatParsha should match Tazria Metzora one week later`() {
+        val calendar = JewishCalendar(
+            LocalDate(year = 2026, monthNumber = 4, dayOfMonth = 18),
+        )
+        val formatter = HebrewDateFormatter()
+
+        assertEquals(
+            "Tazria Metzora",
+            formatter.formatParsha(calendar),
+        )
+    }
+
+    @Test
+    fun `getMonthForValue should wrap correctly around boundaries`() {
+        assertEquals(HebrewMonth.NISSAN, HebrewMonth.Companion.getMonthForValue(1))
+        assertEquals(HebrewMonth.ADAR_II, HebrewMonth.Companion.getMonthForValue(13))
+        assertEquals(HebrewMonth.ADAR_II, HebrewMonth.Companion.getMonthForValue(0))
+        assertEquals(HebrewMonth.ADAR, HebrewMonth.Companion.getMonthForValue(-1))
+        assertEquals(HebrewMonth.NISSAN, HebrewMonth.Companion.getMonthForValue(14))
+        assertEquals(HebrewMonth.IYAR, HebrewMonth.Companion.getMonthForValue(15))
+    }
+
+    @Test
+    fun `Nissan previousMonth should be Adar II`() {
+        assertEquals(
+            HebrewMonth.ADAR_II,
+            HebrewMonth.NISSAN.previousMonth,
+        )
+    }
+
+    @Test
+    fun `daysSinceStartOfJewishYear should increase from 24 Nissan to 1 Iyar`() {
+        val nissan24 = JewishDate(
+            hebrewYear = 5786,
+            hebrewMonth = HebrewMonth.NISSAN,
+            hebrewDayOfMonth = 24,
+        )
+        val iyar1 = JewishDate(
+            hebrewYear = 5786,
+            hebrewMonth = HebrewMonth.IYAR,
+            hebrewDayOfMonth = 1,
+        )
+
+        assertTrue(
+            nissan24.daysSinceStartOfJewishYear < iyar1.daysSinceStartOfJewishYear,
+            "Expected 24 Nissan to be before 1 Iyar within the same Jewish year",
+        )
+    }
+
+    @Test
+    fun `daysSinceStartOfJewishYear should increase day by day within Nissan`() {
+        val day18 = JewishDate(
+            hebrewYear = 5786,
+            hebrewMonth = HebrewMonth.NISSAN,
+            hebrewDayOfMonth = 18,
+        )
+        val day19 = JewishDate(
+            hebrewYear = 5786,
+            hebrewMonth = HebrewMonth.NISSAN,
+            hebrewDayOfMonth = 19,
+        )
+
+        assertEquals(
+            day18.daysSinceStartOfJewishYear + 1,
+            day19.daysSinceStartOfJewishYear,
+        )
+    }
+
+    @Test
+    fun `upcomingParshah should remain stable throughout the same week before Shabbos`() {
+        val sunday = JewishCalendar(LocalDate(year = 2026, monthNumber = 4, dayOfMonth = 5))
+        val monday = JewishCalendar(LocalDate(year = 2026, monthNumber = 4, dayOfMonth = 6))
+        val tuesday = JewishCalendar(LocalDate(year = 2026, monthNumber = 4, dayOfMonth = 7))
+        val wednesday = JewishCalendar(LocalDate(year = 2026, monthNumber = 4, dayOfMonth = 8))
+        val thursday = JewishCalendar(LocalDate(year = 2026, monthNumber = 4, dayOfMonth = 9))
+        val friday = JewishCalendar(LocalDate(year = 2026, monthNumber = 4, dayOfMonth = 10))
+
+        assertEquals(JewishCalendar.Parsha.SHMINI, sunday.upcomingParshah)
+        assertEquals(JewishCalendar.Parsha.SHMINI, monday.upcomingParshah)
+        assertEquals(JewishCalendar.Parsha.SHMINI, tuesday.upcomingParshah)
+        assertEquals(JewishCalendar.Parsha.SHMINI, wednesday.upcomingParshah)
+        assertEquals(JewishCalendar.Parsha.SHMINI, thursday.upcomingParshah)
+        assertEquals(JewishCalendar.Parsha.SHMINI, friday.upcomingParshah)
+    }
+}

--- a/composeApp/src/test/kotlin/hebrewcalendar/JewishCalendarParshaRegressionTest.kt
+++ b/composeApp/src/test/kotlin/hebrewcalendar/JewishCalendarParshaRegressionTest.kt
@@ -63,12 +63,12 @@ class JewishCalendarParshaRegressionTest {
 
     @Test
     fun `getMonthForValue should wrap correctly around boundaries`() {
-        assertEquals(HebrewMonth.NISSAN, HebrewMonth.Companion.getMonthForValue(1))
-        assertEquals(HebrewMonth.ADAR_II, HebrewMonth.Companion.getMonthForValue(13))
-        assertEquals(HebrewMonth.ADAR_II, HebrewMonth.Companion.getMonthForValue(0))
-        assertEquals(HebrewMonth.ADAR, HebrewMonth.Companion.getMonthForValue(-1))
-        assertEquals(HebrewMonth.NISSAN, HebrewMonth.Companion.getMonthForValue(14))
-        assertEquals(HebrewMonth.IYAR, HebrewMonth.Companion.getMonthForValue(15))
+        assertEquals(HebrewMonth.NISSAN, HebrewMonth.getMonthForValue(1))
+        assertEquals(HebrewMonth.ADAR_II, HebrewMonth.getMonthForValue(13))
+        assertEquals(HebrewMonth.ADAR_II, HebrewMonth.getMonthForValue(0))
+        assertEquals(HebrewMonth.ADAR, HebrewMonth.getMonthForValue(-1))
+        assertEquals(HebrewMonth.NISSAN, HebrewMonth.getMonthForValue(14))
+        assertEquals(HebrewMonth.IYAR, HebrewMonth.getMonthForValue(15))
     }
 
     @Test


### PR DESCRIPTION
This PR fixes an issue where incorrect parsha values were returned (e.g. returning "Sh'lach" instead of "Shmini" for 18 Nissan 5786).

Root cause:
The Kotlin implementation of `getDaysSinceStartOfJewishYear` iterated over `HebrewMonth` using enum ranges (`..` / `until`).  
Unlike the original Java implementation (which uses integer-based month values), this introduced incorrect behavior due to the circular nature of the enum (`nextMonth` / `previousMonth`) and range iteration.

In particular:
- Enum-based iteration is not strictly linear
- Range boundaries depend on `previousMonth`, which can produce incorrect ranges
- This led to incorrect day offsets within the year
- As a result, parsha calculation (which depends on day offsets) returned incorrect values

Solution:
The implementation now uses the numeric `value` of `HebrewMonth` (1–13) for iteration, matching the original Java logic.

This ensures:
- Correct linear iteration over months
- Consistent behavior with the Java implementation
- Accurate day calculations and correct parsha results

Additional notes:
- Also fixed wrapping logic in `getMonthForValue` to correctly handle negative and zero values using modulo
- This prevents incorrect `previousMonth` results (e.g. Nissan → Iyar instead of Adar II)

After this fix:
Parsha calculation aligns with expected results for all tested dates.
